### PR TITLE
Consider Time.near when returning search results

### DIFF
--- a/sunpy_soar/client.py
+++ b/sunpy_soar/client.py
@@ -5,7 +5,7 @@ import numpy as np
 
 from sunpy import log
 import sunpy.net.attrs as a
-from sunpy.net.attr import and_, AttrAnd, AttrOr
+from sunpy.net.attr import and_, AttrAnd
 from sunpy.net.base_client import BaseClient, QueryResponseTable
 from sunpy.time import parse_time
 
@@ -23,8 +23,7 @@ class SOARClient(BaseClient):
         query = and_(*query)
         queries = walker.create(query)
 
-        # Find all of the near attributes on the Time attr if they
-        # are specified
+        # For each query, find the Time attr and get the near time
         t_near = []
         for q in [query] if isinstance(query, AttrAnd) else query:
             t_near.append([aq for aq in q.attrs if isinstance(aq, a.Time)][0].near)


### PR DESCRIPTION
Fixes #7 

This feels really hacky and the code makes me a bit ill looking at it, but it does work. 😅  

From what I can tell, post-search hooks are not a thing for full clients so I'm not sure if there is a better place to put this. The filtering inside the query_parameters iteration could be pulled into a separate function to clean things up.